### PR TITLE
fix: add build step and drop support for Astro v2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
    - package-ecosystem: "github-actions"
      directory: "/"
      schedule:
-        interval: "weekly"
+        interval: "monthly"
         day: "saturday"
         time: "00:00"
         timezone: "America/Costa_Rica"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,21 +22,19 @@ jobs:
               node-version: lts/*
               registry-url: https://registry.npmjs.org/
 
-         - name: Update npm
-           run: npm install -g npm@latest
+         - run: npm install -g npm@latest
 
-         - uses: pnpm/action-setup@v4
+         - uses: pnpm/action-setup@v6
+           with:
+              version: latest
 
-         - name: Generate release changelog
-           run: pnpx changelogithub
+         - run: pnpx changelogithub
            env:
               GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
-         - name: Install dependencies
-           run: pnpm install --no-frozen-lockfile
+         - run: pnpm install --no-frozen-lockfile
 
-         - name: Publish to npm
-           run: |
+         - run: |
               TAG="${GITHUB_REF_NAME}"
               if [[ "$TAG" == *"beta"* ]]; then
                  echo "Publishing beta version"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,6 +56,9 @@ jobs:
          - name: Install
            run: pnpm install
 
+         - name: Build
+           run: pnpm build
+
          - name: Test
            run: pnpm test
 

--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,5 @@ pnpm-lock.yaml
 
 # Astro types
 .astro
+
+dist

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -11,7 +11,7 @@ import pluginYml from 'eslint-plugin-yml'
 import neostandard, { plugins, resolveIgnoresFromGitignore } from 'neostandard'
 
 export default defineConfig([
-  globalIgnores([...resolveIgnoresFromGitignore(), 'pnpm-lock.yaml', './tests/fixtures/**']),
+  globalIgnores([...resolveIgnoresFromGitignore(), 'pnpm-lock.yaml', './tests/fixtures/**', 'dist']),
   { languageOptions: { globals: { ...globals.browser, ...globals.node } } },
   pluginJs.configs.recommended,
   neostandard({

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   },
   "sideEffects": false,
   "peerDependencies": {
-    "astro": ">=2.8"
+    "astro": ">=3.6"
   },
   "author": "Felix Icaza <fx.joliett17@gmail.com>"
 }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "lint": "eslint --cache .",
     "lint:fix": "eslint --cache --fix .",
     "prepare": "simple-git-hooks",
+    "prepublishOnly": "pnpm build",
     "release": "bumpp",
     "test": "vitest",
     "test:fixtures": "pnpm -r build"

--- a/package.json
+++ b/package.json
@@ -21,11 +21,21 @@
   },
   "license": "MIT",
   "type": "module",
-  "exports": "./src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.mts",
+      "import": "./dist/index.mjs"
+    }
+  },
+  "main": "./dist/index.mjs",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.mts",
   "files": [
-    "src"
+    "dist"
   ],
   "scripts": {
+    "build": "tsdown",
+    "dev": "tsdown --watch",
     "lint": "eslint --cache .",
     "lint:fix": "eslint --cache --fix .",
     "prepare": "simple-git-hooks",
@@ -44,6 +54,7 @@
   },
   "devDependencies": {
     "@eslint/js": "9.39.1",
+    "@felixicaza/tsdown-config": "0.1.1",
     "@typescript-eslint/parser": "8.59.3",
     "astro": "6.3.3",
     "bumpp": "11.1.0",
@@ -57,6 +68,7 @@
     "nano-staged": "1.0.2",
     "neostandard": "0.13.0",
     "simple-git-hooks": "2.13.1",
+    "tsdown": "0.22.0",
     "vitest": "4.1.6"
   },
   "sideEffects": false,

--- a/tests/fixtures/base/package.json
+++ b/tests/fixtures/base/package.json
@@ -12,6 +12,7 @@
     "preview": "astro preview"
   },
   "dependencies": {
+    "@felixicaza/astro-capo": "workspace:*",
     "astro": "6.3.3"
   }
 }

--- a/tests/fixtures/base/src/layouts/Layout.astro
+++ b/tests/fixtures/base/src/layouts/Layout.astro
@@ -1,5 +1,5 @@
 ---
-import { Head } from '@Head'
+import { Head } from '@felixicaza/astro-capo'
 ---
 
 <!doctype html>

--- a/tests/fixtures/base/tsconfig.json
+++ b/tests/fixtures/base/tsconfig.json
@@ -1,11 +1,5 @@
 {
   "extends": "astro/tsconfigs/strict",
   "include": [".astro/types.d.ts", "**/*"],
-  "exclude": ["dist"],
-  "compilerOptions": {
-    "baseUrl": ".",
-    "paths": {
-      "@Head": ["../../../src/index.ts"]
-    }
-  }
+  "exclude": ["dist"]
 }

--- a/tests/fixtures/client-router/package.json
+++ b/tests/fixtures/client-router/package.json
@@ -12,6 +12,7 @@
     "preview": "astro preview"
   },
   "dependencies": {
+    "@felixicaza/astro-capo": "workspace:*",
     "astro": "6.3.3"
   }
 }

--- a/tests/fixtures/client-router/src/layouts/Layout.astro
+++ b/tests/fixtures/client-router/src/layouts/Layout.astro
@@ -1,7 +1,7 @@
 ---
 import { ClientRouter } from 'astro:transitions'
 
-import { Head } from '@Head'
+import { Head } from '@felixicaza/astro-capo'
 ---
 
 <!doctype html>

--- a/tests/fixtures/client-router/tsconfig.json
+++ b/tests/fixtures/client-router/tsconfig.json
@@ -1,11 +1,5 @@
 {
   "extends": "astro/tsconfigs/strict",
   "include": [".astro/types.d.ts", "**/*"],
-  "exclude": ["dist"],
-  "compilerOptions": {
-    "baseUrl": ".",
-    "paths": {
-      "@Head": ["../../../src/index.ts"]
-    }
-  }
+  "exclude": ["dist"]
 }

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -1,0 +1,3 @@
+import { felixicaza } from '@felixicaza/tsdown-config'
+
+export default felixicaza()


### PR DESCRIPTION
- Additional build step using tsdown has been added, so that when it is published to npm, the file size will be smaller.
- Drop support for Astro v2.